### PR TITLE
Adding hebrew.js and tests

### DIFF
--- a/static/js/hebrew.js
+++ b/static/js/hebrew.js
@@ -35,25 +35,6 @@ function sum(list) {
     }, 0);
 }
 
-//function acc(callback) {
-//
-//    return function(previous, current, index, array) {
-//
-//        if (index === 0 && !(previous instanceof Array)) {
-//            previous = [previous];
-//        }
-//
-//        previous.push(callback(current, index, array));
-//        return previous;
-//
-//    };
-//
-//}
-
-//function enumerate(list) {
-//    return list.reduce(acc(function(curr, index) {return [index, curr];}));
-//}
-
 // Bad idea?
 Array.prototype.callOnMyself = function(callback) {
     return callback(this, arguments);
@@ -125,7 +106,7 @@ var splitThousands = function(n, littleEndian) {
 var hebStringToInt = function(n) {
 
     return n.replace(/[\u05F4\"]/g, '').split('')
-                .reduce(function(a, b) {a.push(hebToInt(b)); return a;}, [])
+                .map(function(a) {return hebToInt(a); })
                 .reduce(function(a, b) { return a + b; }, 0);
 
 };
@@ -137,10 +118,8 @@ var decodeHebrewNumeral = function(n) {
         return a;
     }, [])
     .callOnMyself(enumerate)
+    .map(function(a) { return Math.pow(10, 3*a[0]) * a[1]; })
     .reduce(function(prev, curr) {
-        prev.push(Math.pow(10, 3*curr[0]) * curr[1]);
-        return prev;
-    }, []).reduce(function(prev, curr) {
         return prev + curr;
     }, 0);
 
@@ -281,19 +260,9 @@ var encodeHebrewNumeral = function(n, punctuation) {
     } else {
         ret = chunks(breakIntMagnitudes(n).reverse(), 3)
             .callOnMyself(enumerate)
-            .reduce(function(prev, curr) {
-                prev.push(
-                    Math.floor(sum(curr[1]) * Math.pow(10, -3 * curr[0]))
-                );
-                return prev;
-            }, [])
+            .map(function(a) { return Math.floor(sum(a[1])) * Math.pow(10, -3 * a[0]); })
             .reverse()
-            .reduce(function(prev, curr) {
-                prev.push(
-                    encodeSmallHebrewNumeral(curr)
-                );
-                return prev;
-            }, [])
+            .map(function(a) { return encodeSmallHebrewNumeral(a); })
             .join(GERESH);
     }
 

--- a/static/js/hebrew.js
+++ b/static/js/hebrew.js
@@ -1,0 +1,302 @@
+/********
+ * Still some work to be done here,
+ *   the numbers don't print right at all yet.
+ *   encodeHebrewNumeral(3) === גגג׳
+ *
+ */
+
+
+
+
+var GERESH = '\u05F3';
+var GERSHAYIM = '\u05F4';
+
+function right(string, numChars) {
+    'use strict';
+    return string.slice(string.length - numChars);
+}
+
+function enumerate(list) {
+
+    return list.reduce(function(prevValue, curValue, index) {
+        prevValue.push([index, curValue]);
+        return prevValue;
+    }, []);
+
+}
+
+function log10(val) {
+    return Math.log(val) / Math.LN10;
+}
+
+function sum(list) {
+    return list.reduce(function(prev, curr) {
+        return prev + curr;
+    }, 0);
+}
+
+//function acc(callback) {
+//
+//    return function(previous, current, index, array) {
+//
+//        if (index === 0 && !(previous instanceof Array)) {
+//            previous = [previous];
+//        }
+//
+//        previous.push(callback(current, index, array));
+//        return previous;
+//
+//    };
+//
+//}
+
+//function enumerate(list) {
+//    return list.reduce(acc(function(curr, index) {return [index, curr];}));
+//}
+
+// Bad idea?
+Array.prototype.callOnMyself = function(callback) {
+    return callback(this, arguments);
+};
+
+var hebToInt = function(unicodeChar) {
+    'use strict';
+
+    var hebrewNumerals = {
+        "\u05D0": 1,
+        "\u05D1": 2,
+        "\u05D2": 3,
+        "\u05D3": 4,
+        "\u05D4": 5,
+        "\u05D5": 6,
+        "\u05D6": 7,
+        "\u05D7": 8,
+        "\u05D8": 9,
+        "\u05D9": 10,
+        "\u05DB": 20,
+        "\u05DC": 30,
+        "\u05DE": 40,
+        "\u05E0": 50,
+        "\u05E1": 60,
+        "\u05E2": 70,
+        "\u05E4": 80,
+        "\u05E6": 90,
+        "\u05E7": 100,
+        "\u05E8": 200,
+        "\u05E9": 300,
+        "\u05EA": 400,
+
+        // "\u05f3": "'", // Hebrew geresh
+        // "\u05F4": '"', // Hebrew gershayim
+    };
+
+    if (hebrewNumerals.hasOwnProperty(unicodeChar)) {
+        return hebrewNumerals[unicodeChar];
+    } else {
+        throw "Invalid Hebrew numeral character " + unicodeChar;
+    }
+
+};
+
+var splitThousands = function(n, littleEndian) {
+
+    // littleEndian defaults to true
+    if (littleEndian === undefined) {
+        littleEndian = true;
+    }
+
+    // Ignore geresh on digit < 10, if present
+
+    if (right(n, 1) === GERESH) {
+        n = n.slice(0, n.length - 1);
+    }
+
+    var re = new RegExp(GERESH, "g");
+
+    var ret = n.replace(re, "'").split("'");
+    if (!!littleEndian) {
+        return ret.reverse();
+    } else {
+        return ret
+    }
+
+};
+
+var hebStringToInt = function(n) {
+
+    return n.replace(/[\u05F4\"]/g, '').split('')
+                .reduce(function(a, b) {a.push(hebToInt(b)); return a;}, [])
+                .reduce(function(a, b) { return a + b; }, 0);
+
+};
+
+var decodeHebrewNumeral = function(n) {
+
+    return splitThousands(n).reduce(function(a, b) {
+        a.push(hebStringToInt(b));
+        return a;
+    }, [])
+    .callOnMyself(enumerate)
+    .reduce(function(prev, curr) {
+        prev.push(Math.pow(10, 3*curr[0]) * curr[1]);
+        return prev;
+    }, []).reduce(function(prev, curr) {
+        return prev + curr;
+    }, 0);
+
+};
+
+
+/******* ENCODING *********/
+
+var chunks = function(l, n) {
+    var out = [];
+    for (var i = 0; i < l.length; i+=n) {
+        out.push(l.slice(i, i + n))
+    }
+
+    return out;
+};
+
+var intToHeb = function(integer) {
+
+    var hebrewNumerals = {
+        0: "",
+        1: "\u05D0",
+        2: "\u05D1",
+        3: "\u05D2",
+        4: "\u05D3",
+        5: "\u05D4",
+        6: "\u05D5",
+        7: "\u05D6",
+        8: "\u05D7",
+        9: "\u05D8",
+        10: "\u05D9",
+        15: "\u05D8\u05D5",  // Will not be hit when used with break_int_magnitudes
+        16: "\u05D8\u05D6",  // Will not be hit when used with break_int_magnitudes
+        20: "\u05DB",
+        30: "\u05DC",
+        40: "\u05DE",
+        50: "\u05E0",
+        60: "\u05E1",
+        70: "\u05E2",
+        80: "\u05E4",
+        90: "\u05E6",
+        100: "\u05E7",
+        200: "\u05E8",
+        300: "\u05E9",
+        400: "\u05EA"
+    };
+
+    // Fill in the hebrewNumerals mappings up to 1100
+    for (var i = 500; i < 1200; i += 100) {
+        hebrewNumerals[i] = Array(Math.floor(i / 400) + 1).join(hebrewNumerals[400]) + hebrewNumerals[i % 400];
+    }
+
+    if (integer > 1100) {
+        throw "Asked to convert individual integer " + integer + " above 1100";
+    } else if (!(integer in hebrewNumerals)) {
+        throw "Asked to convert integer " + integer + " that lacks individual Hebrew character";
+    } else {
+        return hebrewNumerals[integer];
+    }
+};
+
+var breakIntMagnitudes = function(n, start) {
+
+    if (start === undefined) {
+        start = Math.pow(10, Math.floor(log10(n)));
+    } else if (!(start % 10 === 0 || start === 1)) {
+        throw "Argument 'start' " + start + " must be 1 or divisible by 10";
+    }
+
+    if (start === 1) {
+        return [n];
+    } else {
+        return [ Math.floor(n / start) * start ].concat(
+            breakIntMagnitudes(n - Math.floor(n / start) * start, start / 10)
+        );
+    }
+
+};
+
+var sanitize = function(inputString, punctuation) {
+
+    if (punctuation === undefined) {
+        punctuation = true;
+    }
+
+    var replacementPairs = [
+        [/\u05d9\u05d4/g, '\u05d8\u05d5'], //15
+        [/\u05d9\u05d5/g, '\u05d8\u05d6'], //16
+        [/\u05e8\u05e2\u05d4/g, '\u05e2\u05e8\u05d4'], //275
+        [/\u05e8\u05e2\u05d1/g, '\u05e2\u05e8\u05d1'], //272
+        [/\u05e8\u05e2/g, '\u05e2\u05e8'], //270
+    ];
+
+    replacementPairs.forEach(function(pair) {
+        inputString = inputString.replace(pair[0], pair[1]);
+    });
+
+    if (punctuation) {
+        // add gershayim at the end if longer than one character
+        if (inputString.length > 1) {
+            // if a geresh is not one of the last two items in the string
+            if (right(inputString, 2).indexOf(GERESH) < 0) {
+                inputString = inputString.substr(0, inputString.length - 1) + GERSHAYIM + right(inputString, 1);
+            }
+        } else {
+            inputString += GERESH;
+        }
+    }
+
+    return inputString;
+
+};
+
+
+var encodeSmallHebrewNumeral = function(n) {
+
+    if (n >= 1200) {
+        throw "Tried to encode small numeral " + n + " greater than 1200";
+    } else {
+        return breakIntMagnitudes(n, 100).reduce(function(prev, curr) {
+            prev.push(intToHeb(curr));
+            return prev;
+        }, []).join('');
+    }
+
+};
+
+var encodeHebrewNumeral = function(n, punctuation) {
+
+    var ret;
+
+    if (punctuation === undefined) {
+        punctuation = true;
+    }
+
+    if ( n < 1200) {
+        ret = encodeSmallHebrewNumeral(n);
+    } else {
+        ret = chunks(breakIntMagnitudes(n).reverse(), 3)
+            .callOnMyself(enumerate)
+            .reduce(function(prev, curr) {
+                prev.push(
+                    Math.floor(sum(curr[1]) * Math.pow(10, -3 * curr[0]))
+                );
+                return prev;
+            }, [])
+            .reverse()
+            .reduce(function(prev, curr) {
+                prev.push(
+                    encodeSmallHebrewNumeral(curr)
+                );
+                return prev;
+            }, [])
+            .join(GERESH);
+    }
+
+    return sanitize(ret, punctuation);
+
+};

--- a/static/js/test/test.js
+++ b/static/js/test/test.js
@@ -1,0 +1,153 @@
+/* Testing done using Jasmine */
+
+describe("Sanity checks", function() {
+    var a;
+    var i;
+
+    it("can encode without throwing errors", function() {
+
+        for (i = 1; i < 5000; i++) {
+            a = encodeHebrewNumeral(i);
+            expect(a).toBeDefined();
+        }
+
+    });
+
+    it("can encode and decode correctly", function() {
+        for (i = 1; i < 5000; i++) {
+
+            // if the number isn't 2/3/4000
+            if ([2000, 3000, 4000].indexOf(i) === -1) {
+                a = decodeHebrewNumeral(encodeHebrewNumeral(i));
+                expect(a).toBe(i);
+            }
+        }
+    });
+
+});
+
+describe("Specific in/out tests", function() {
+
+    describe("Basic encoding tests", function () {
+        var a;
+
+        it("can encode 300", function () {
+            a = encodeHebrewNumeral(300);
+            expect(a).toBe('ש׳');
+        });
+
+        it("can encode 33 with punctuation flag", function () {
+            a = encodeHebrewNumeral(33, true);
+            expect(a).toBe("ל״ג");
+        });
+
+        it("can encode encode 5764", function () {
+            a = encodeHebrewNumeral(5764);
+            expect(a).toBe("ה׳תשס״ד");
+        });
+
+        it("can encode 1000005", function () {
+            a = encodeHebrewNumeral(1000005);
+            expect(a).toBe("א׳׳ה");
+        });
+
+    });
+
+    describe("Basic encoding special cases", function () {
+        var a;
+
+        it("can encode 275", function () {
+            a = encodeHebrewNumeral(275);
+            expect(a).toBe("ער״ה");
+        });
+
+        it("can encode 270", function () {
+            a = encodeHebrewNumeral(270);
+            expect(a).toBe("ע״ר");
+        });
+
+        it("can encode 272", function () {
+            a = encodeHebrewNumeral(272);
+            expect(a).toBe("ער״ב");
+        });
+
+        it("can encode 15", function () {
+            a = encodeHebrewNumeral(15);
+            expect(a).toBe("ט״ו");
+        });
+
+        it("can encode 16", function () {
+            a = encodeHebrewNumeral(16);
+            expect(a).toBe("ט״ז");
+        });
+    });
+
+    describe("Basic encoding without punctuation", function () {
+        var a;
+
+        it("can encode 35 without punctuation", function () {
+            a = encodeHebrewNumeral(35, false);
+            expect(a).toBe("לה");
+        });
+
+        it("can encode 42 without punctuation", function () {
+            a = encodeHebrewNumeral(42, false);
+            expect(a).toBe("מב");
+        });
+
+        it("can encode 129 without punctuation", function () {
+            a = encodeHebrewNumeral(129, false);
+            expect(a).toBe("קכט");
+        });
+    });
+
+    describe("Basic decoding tests", function () {
+        var a;
+
+        it("can decode א", function () {
+            a = decodeHebrewNumeral("א");
+            expect(a).toBe(1);
+        });
+
+        it("can decode תתש", function () {
+            a = decodeHebrewNumeral("תתש");
+            expect(a).toBe(1100);
+        });
+
+        it("can decode תקט״ו", function () {
+            a = decodeHebrewNumeral("תקט״ו");
+            expect(a).toBe(515);
+        });
+
+        it("can decode ה׳תשס״ד", function () {
+            a = decodeHebrewNumeral("ה׳תשס״ד");
+            expect(a).toBe(5764);
+        });
+
+    });
+
+    describe("undefined conventions", function () {
+        var a;
+
+        it("deals with 15000", function () {
+            a = encodeHebrewNumeral(15000);
+            expect(a).toBe("טו׳");
+        });
+
+        it("deals with 16000", function () {
+            a = encodeHebrewNumeral(16000);
+            expect(a).toBe("טז׳");
+        });
+    });
+
+});
+
+describe("Utility function tests", function() {
+
+    it("should break 15000 correctly", function() {
+        expect(breakIntMagnitudes(15000)).toEqual(
+            [10000, 5000, 0, 0, 0]
+        );
+    });
+
+});


### PR DESCRIPTION
I've ported the hebrew.py code to Javascript in hebrew.js, and also added testing for it using Jasmine.

Not quite sure where the Javascript should go, so I put it in the Sefaria-Project/static/js folder, and the tests folder for js under that as well.

The numbering conventions, etc. are all the same as in the Python.