### PR TITLE
Source Sheet: Autosave layout change only on 'OK' button

### DIFF
--- a/static/js/sheets.js
+++ b/static/js/sheets.js
@@ -760,7 +760,6 @@ $(function() {
 		} else {
 			$("#biLayoutToggleSource").removeClass("disabled");
 		}
-		autoSave();
 		sjs.track.sheets("Change Source Layout Button");
 	});
 
@@ -782,7 +781,6 @@ $(function() {
 				$("#biLayoutToggleSource").removeClass("disabled");
 			}
 		}
-		autoSave();		
 		sjs.track.sheets("Change Source Language Button");
 	});
 	
@@ -793,7 +791,6 @@ $(function() {
 		$(this).addClass("active");
 		$target.removeClass("hebLeft hebRight")
 			.addClass($(this).attr("id").replace("Source",""))
-		autoSave();	
 		sjs.track.sheets("Change Source Language Layout Button");
 	});
 


### PR DESCRIPTION
The previous behavior was causing errors on production and preventing
any changes to older source texts.